### PR TITLE
Support four-channel triple confidence tensors

### DIFF
--- a/nsm/data/dataset.py
+++ b/nsm/data/dataset.py
@@ -335,8 +335,8 @@ class SyntheticTripleDataset(BaseSemanticTripleDataset):
             predicate = f"pred_{torch.randint(0, self.num_predicates, (1,)).item()}"
             obj = f"entity_{torch.randint(0, self.num_entities, (1,)).item()}"
 
-            # Random confidence and level
-            confidence = torch.rand(1).item()
+            # Random confidence log-scores and level
+            confidence = torch.log_softmax(torch.randn(4), dim=0)
             level = torch.randint(1, self.num_levels + 1, (1,)).item()
 
             triple = SemanticTriple(


### PR DESCRIPTION
## Summary
- update `SemanticTriple` to normalize scalar and four-channel confidence inputs while keeping legacy scalar consumers happy and expose tensor helpers
- adapt `TripleCollection`, `GraphConstructor`, and synthetic dataset generation to work with four-value log-score tensors
- extend unit coverage to validate both scalar compatibility and the new four-channel data path

## Testing
- pytest --override-ini addopts= tests/data/test_triple.py *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68f711c1b8b483248485dc552f5536d3